### PR TITLE
Fix for "Uncaught Error" in parser

### DIFF
--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -325,7 +325,7 @@ function generic_parser_b($rawdata, $items = [], $dateformat = 'mdy', $hasreg = 
         ];
     }
 
-    $r = '';
+    $r = array(); // fix for issue with PHP7 as discussed on in https://stackoverflow.com/questions/1873970/cannot-use-string-offset-as-an-array-in-php 
     $disok = true;
 
     while (list($key, $val) = \each($rawdata)) {


### PR DESCRIPTION
Running this on PHP 7.x I experienced an Uncaught error:

AH01071: Got error 'PHP message: PHP Warning:  Illegal string offset 'disclaimer' in /websitepath/phpwhois/whois.parser.php on line 350\nPHP message: PHP Fatal error:  Uncaught Error: Cannot use string offset as an array in /websitepath/phpwhois/whois.parser.php:350\nStack trace:\n#0 /websitepath/phpwhois/whois.ip.arin.php(70): generic_parser_b(Array, Array, 'ymd', false, true)\n#1 /websitepath/phpwhois/whois.client.php(469): arin_handler->parse(Array, '94.167.0.59')\n#2 /websitepath/phpwhois/whois.ip.php(181): WhoisClient->Process(Array)\n#3 /websitepath/phpwhois/whois.ip.php(129): ip_handler->parse_results(Array, Array, '94.167.0.59', true)\n#4 /websitepath/phpwhois/whois.client.php(469): ip_handler->parse(Array, '94.167.0.59')\n#5 /websitepath/phpwhois/whois.client.php(254): WhoisClient->Process(Array, true)\n#6 /websitepath/phpwhois/whois.main.php(127): WhoisClient->GetData('94.167.0.59', true)\n#7 /websitepath/phpwhois/example.php(63): Whois->Lookup...\n', referer: https://websitepath/phpwhois/example.php
AH01071: Got error 'PHP message: PHP Warning:  Illegal string offset 'disclaimer' in /site/phpwhois/whois.parser.php on line 350\nPHP message: PHP Fatal error:  Uncaught Error: Cannot use string offset as an array in /websitepath/phpwhois/whois.parser.php:350\nStack trace:\n#0 /websitepath/phpwhois/whois.ip.arin.php(70): generic_parser_b(Array, Array, 'ymd', false, true)\n#1 /websitepath/phpwhois/whois.client.php(469): arin_handler->parse(Array, '94.167.0.59')\n#2 /websitepath/phpwhois/whois.ip.php(181): WhoisClient->Process(Array)\n#3 /websitepath/phpwhois/whois.ip.php(129): ip_handler->parse_results(Array, Array, '94.167.0.59', true)\n#4 /websitepath/phpwhois/whois.client.php(469): ip_handler->parse(Array, '94.167.0.59')\n#5 /websitepath/phpwhois/whois.client.php(254): WhoisClient->Process(Array, true)\n#6 /websitepath/phpwhois/whois.main.php(127): WhoisClient->GetData('94.167.0.59', true)\n#7 /websitepath/phpwhois/example.php(63): Whois->Lookup...\n', referer: https://websitepath/phpwhois/example.php

The fix implements the suggestion found on this stackoverflow thread https://stackoverflow.com/questions/1873970/cannot-use-string-offset-as-an-array-in-php and seems to work on my server.