### PR TITLE
Update whois.parser.php

### DIFF
--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -325,7 +325,7 @@ function generic_parser_b($rawdata, $items = [], $dateformat = 'mdy', $hasreg = 
         ];
     }
 
-    $r = '';
+    $r = [];
     $disok = true;
 
     while (list($key, $val) = \each($rawdata)) {


### PR DESCRIPTION
$r for eval

see line :351
```php
eval($var.'="'.\str_replace('"', '\"', $itm).'";');
```

eval function parameter example：
```
$r["domain"]["name"]="aaa.com";
```
But $r is string

you see : https://www.php.net/manual/en/language.types.string.php

> Warning:
> Writing to an out of range offset pads the string with spaces. Non-integer types are converted to integer. Illegal offset type emits E_WARNING. Only the first character of an assigned string is used. As of PHP 7.1.0, assigning an empty string throws a fatal error. Formerly, it assigned a NULL byte.


sorry ,my English is poor...